### PR TITLE
Always show breadcrumbs.

### DIFF
--- a/Service/BreadcrumbService.php
+++ b/Service/BreadcrumbService.php
@@ -108,7 +108,7 @@ class BreadcrumbService
         $parents = $this->getParents($name);
         $breadcrumbs = array();
 
-        if ($route && $parents) {
+        if ($route) {
             foreach (
                 array_merge($parents, array($name)) as $current
             ) {


### PR DESCRIPTION
Shouldn't this bundle offer the flexibility to always show breadcrumbs, even if there are no parents, for example for the homepage?

I'd say this would be the more common use-case, and even so, it's relatively easy to use blocks to hide breadcrumbs in particular templates than it is to put them back in once this logic removes them.

At the very least this should be configurable from config, if the above change is not sufficient.
