### PR TITLE
Get the URI without GET parameters

### DIFF
--- a/Twig/Extension/BreadcrumbExtension.php
+++ b/Twig/Extension/BreadcrumbExtension.php
@@ -53,7 +53,7 @@ class BreadcrumbExtension extends Twig_Extension
         $request = $this->container->get('request');
 
         $route = $request->get('_route');
-        $params = $router->match($request->getRequestUri());
+        $params = $router->match($request->getPathInfo());
 
         return $this->container->get("templating")->render(
             "XiBreadcrumbsBundle:Default:breadcrumbs.html.twig",


### PR DESCRIPTION
By using `getPathInfo()` it will get the URI without the GET parameters (e.g. ?foo=bar) which breaks the breadcrumb functionality as it won't find any matching routes.
