### PR TITLE
Support for using properties/getters for label creation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,18 +11,18 @@
         }
     ],
     "require": {
-        "symfony/framework-bundle": "2.1.*",
-        "symfony/locale": "2.1.*",
-        "symfony/twig-bundle": "2.1.*",
-        "symfony/yaml": "2.1.*"
+        "symfony/framework-bundle": "2.3.6",
+        "symfony/locale": "2.3.6",
+        "symfony/twig-bundle": "2.3.6",
+        "symfony/yaml": "2.3.6"
     },
     "require-dev": {
-        "besimple/i18n-routing-bundle": "2.1.*@dev",
-        "symfony/browser-kit": "2.1.*",
-        "symfony/class-loader": "2.1.*",
-        "symfony/css-selector": "2.1.*",
-        "symfony/finder": "2.1.*",
-        "symfony/form": "2.1.*"
+        "besimple/i18n-routing-bundle": "2.3.6",
+        "symfony/browser-kit": "2.3.6",
+        "symfony/class-loader": "2.3.6",
+        "symfony/css-selector": "2.3.6",
+        "symfony/finder": "2.3.6",
+        "symfony/form": "2.3.6"
     },
     "suggest": {
         "besimple/i18n-routing-bundle": "Enables internationalised routes and breadcrumbs."


### PR DESCRIPTION
Related to issue #3.

I added support for using properties/getters for label creation when using the ParamConverter from the [SensioFrameworkExtraBundle](https://github.com/sensiolabs/SensioFrameworkExtraBundle). In your routing file you can define which property or getter method to use.

Use the ParamConverter in your controller to get the entity:

```
use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;

/**
 * @ParamConverter(name="user", class="MyBundle:User")
 */
public function viewAction($user)
{
    //
}
```

In your routing.yml define which property/getter to use in the breadcrumb labels:

```
users_view:
    pattern: /users/view/{user}
    defaults:
        _controller: MyBundle:User:view
        parent: "users_index"
        label: "{user}"
        properties:
            user: fullName
```

This will get the user entity from the request (which Sensio's ParamConverter has converted from an id to an entity). It will check if the entity has a public property fullName. If not, it will try to use the public getter method getFullName(). If that also fails, it will try to use the entity's __toString() magic fuction.
