### PR TITLE
Repeated parameters cause an issue

### DIFF
--- a/Service/BreadcrumbService.php
+++ b/Service/BreadcrumbService.php
@@ -113,8 +113,8 @@ class BreadcrumbService
                 array_merge($parents, array($name)) as $current
             ) {
                 $breadcrumbs[$current] = new Breadcrumb(
-                    $this->getLabel($current, $params),
-                    $this->getUrl($current, $params)
+                    $this->getLabel($current, $current === $name ? $params : []),
+                    $this->getUrl($current, $current === $name ? $params : [])
                 );
             }
         }


### PR DESCRIPTION
Apply parameters to just the current route, rather than every route in the tree. This fixes an issue which was causing a child {parameter} to be overwritten by a parent {parameter} with the same name.
