### PR TITLE
Fix single item, parent cyclic

### DIFF
--- a/Service/BreadcrumbService.php
+++ b/Service/BreadcrumbService.php
@@ -144,11 +144,17 @@ class BreadcrumbService
     {
         $parents = array();
         $parent = $this->getParent($route);
+        $counter = 0;
 
-        // Prevents circular loops by checking that the key doesn't exist already
-        while ($parent && $parent !== $route && !array_key_exists($parent, $parents)) {
-            $parents[$parent] = count($parents);
-            $parent = $this->getParent($parent);
+        // Prevents circular loops by checking that the key doesn't exist already and authorize single parent
+        while ($parent && !array_key_exists($parent, $parents)) {
+            if ($counter == 0 || ($counter > 0 && $parent !== $route)) {
+                ++$counter;
+                $parents[$parent] = count($parents);
+                $parent = $this->getParent($parent);
+            } else {
+                break;
+            }
         }
 
         return array_reverse(array_flip($parents));
@@ -299,7 +305,7 @@ class BreadcrumbService
 
     private function localizeName($name, $locale = null)
     {
-        return ($locale or $locale = Locale::getDefault()) ? $name .'.'. $locale : $name;
+        return ($locale || $locale = Locale::getDefault()) ? $name .'.'. $locale : $name;
     }
 
     private function getHash($route, $params)

--- a/Tests/Service/BreadcrumbServiceTest.php
+++ b/Tests/Service/BreadcrumbServiceTest.php
@@ -171,8 +171,8 @@ class BreadcrumbServiceTest extends ContainerTestCase
     {
         $this->useRouter('circular.yml');
 
-        $this->assertEquals(array(), $this->service->getBreadcrumbs('loop'));
-        $this->assertEquals(array(), $this->service->getParents('loop'));
+        $this->assertEquals(array('loop' => new Breadcrumb('loop', '/loop')), $this->service->getBreadcrumbs('loop'));
+        $this->assertEquals(array('loop'), $this->service->getParents('loop'));
 
         $this->assertEquals(array('flip'), $this->service->getParents('flop'));
         $this->assertEquals(array('flop'), $this->service->getParents('flip'));
@@ -186,6 +186,7 @@ class BreadcrumbServiceTest extends ContainerTestCase
             'c' => new Breadcrumb('c', '/c'),
             'r' => new Breadcrumb('r', '/r')
         );
+
         $this->assertEquals(
             $this->array_get($cycle, array('c', 'd', 'a')),
             $this->service->getBreadcrumbs('c')


### PR DESCRIPTION
Route now accept only one parent for one item, circular.
